### PR TITLE
Add equality method

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,10 @@ Vector.prototype.toObject = function () {
   return { x: this.x, y: this.y };
 };
 
+Vector.prototype.equals = function (vec) {
+  return this.x === vec.x && this.y === vec.y;
+}
+
 var degrees = 180 / Math.PI;
 
 function radian2degrees (rad) {

--- a/test/test.js
+++ b/test/test.js
@@ -234,4 +234,16 @@ describe('utility methods', function () {
     expect(ret).to.be.instanceof(Object);
     expect(ret).to.eql({ x: 100, y: 200 });
   });
+
+  it('should compare two equal objects', function () {
+    var vec1 = new Vector(1, 2);
+    var vec2 = new Vector(1, 2);
+    expect(vec1.equals(vec2)).to.be.true;
+  });
+
+  it('should compare two non-equal objects', function () {
+    var vec1 = new Vector(1, 2);
+    var vec2 = new Vector(2, 1);
+    expect(vec1.equals(vec2)).to.be.false;
+  });
 });


### PR DESCRIPTION
Note: This also works for e.g. `new Vector(1, 2).equals({x: 1, y: 2})`. We could disallow that by doing a type check on the input - `if (vec instanceof Vector) {...}` - but I'm not sure if it's necessary.
