### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "coordinates",
     "immutable"
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/neojski/immutable-vector2d"


### PR DESCRIPTION
Makes it easier for services like [libraries.io](http://libraries.io) to parse info about the repo: https://libraries.io/npm/immutable-vector2d 

![image](https://cloud.githubusercontent.com/assets/1884486/10218494/ff294f00-682e-11e5-9062-3e2aaf49c1c9.png)
